### PR TITLE
telescope の拡張と設定を追加

### DIFF
--- a/mac/nvim/lua/plugins/telescope.lua
+++ b/mac/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,62 @@
+return {
+  "nvim-telescope/telescope.nvim",
+  cmd = "Telescope",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    {
+      "nvim-telescope/telescope-fzf-native.nvim",
+      build = "make",
+    },
+    "nvim-telescope/telescope-ui-select.nvim",
+  },
+  keys = {
+    {
+      "<leader>ff",
+      function()
+        require("telescope.builtin").find_files()
+      end,
+      desc = "Find Files",
+    },
+    {
+      "<leader>fg",
+      function()
+        require("telescope.builtin").live_grep()
+      end,
+      desc = "Live Grep",
+    },
+    {
+      "<leader>fb",
+      function()
+        require("telescope.builtin").buffers()
+      end,
+      desc = "Find Buffers",
+    },
+    {
+      "<leader>fh",
+      function()
+        require("telescope.builtin").help_tags()
+      end,
+      desc = "Help Tags",
+    },
+  },
+  opts = function(_, opts)
+    local actions = require("telescope.actions")
+
+    opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
+      mappings = {
+        i = {
+          ["<C-j>"] = actions.move_selection_next,
+          ["<C-k>"] = actions.move_selection_previous,
+        },
+      },
+    })
+    opts.extensions = opts.extensions or {}
+    opts.extensions["ui-select"] = require("telescope.themes").get_dropdown({})
+  end,
+  config = function(_, opts)
+    local telescope = require("telescope")
+    telescope.setup(opts)
+    telescope.load_extension("fzf")
+    telescope.load_extension("ui-select")
+  end,
+}


### PR DESCRIPTION
### Motivation
- `telescope` の操作性と検索体験を向上させるためにネイティブ `fzf` と `ui-select` を導入する目的です。
- キーマップの操作を改善して一覧内の選択移動を直感的にしたい意図です。

### Description
- `mac/nvim/lua/plugins/telescope.lua` に依存として `"nvim-telescope/telescope-fzf-native.nvim"`（`build = "make"`）と `"nvim-telescope/telescope-ui-select.nvim"` を追加しました。
- プラグインは遅延ロードのまま `cmd = "Telescope"` を維持し、キーは `<leader>ff`, `<leader>fg`, `<leader>fb`, `<leader>fh` を定義しています。
- `opts` 関数を追加して `telescope.actions` を使いインサートモードで `<C-j>`/`<C-k>` による選択移動を設定し、`ui-select` 用に `opts.extensions["ui-select"] = require("telescope.themes").get_dropdown({})` を設定しました。
- `config` 関数を追加して `require("telescope").setup(opts)` を呼び出し、`fzf` と `ui-select` 拡張を `telescope.load_extension` でロードするようにしました。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b1c6942083309a96f9734d41c7b8)