### PR TITLE
add: github/copilot.vim プラグインを追加

### DIFF
--- a/mac/nvim/lua/plugins/copilot.lua
+++ b/mac/nvim/lua/plugins/copilot.lua
@@ -1,0 +1,3 @@
+return {
+  "github/copilot.vim",
+}


### PR DESCRIPTION
## Summary
- Neovimに `github/copilot.vim` プラグインを追加
- LazyVimのプラグイン管理に従い `mac/nvim/lua/plugins/copilot.lua` を新規作成

## Test plan
- [ ] Neovimを起動し、`:Lazy` でcopilot.vimがインストールされることを確認
- [ ] `:Copilot setup` でGitHub認証を完了
- [ ] コード入力時にCopilotの補完候補が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)