### PR TITLE
add: Claude Codeのpermissions設定を追加

### DIFF
--- a/mac/claude/settings.json
+++ b/mac/claude/settings.json
@@ -1,13 +1,47 @@
 {
   "enabledPlugins": {},
+  "permissions": {
+    "allow": [
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(npm run *)",
+      "Bash(npm test *)",
+      "Bash(npm start *)",
+      "Bash(npm exec *)",
+      "Bash(npm ls *)",
+      "Bash(npm outdated *)",
+      "Bash(npm info *)",
+      "Bash(npx *)",
+      "Bash(deno run *)",
+      "Bash(deno test *)",
+      "Bash(deno task *)",
+      "Bash(deno fmt *)",
+      "Bash(deno lint *)",
+      "Bash(deno check *)",
+      "Bash(deno bench *)",
+      "Bash(deno doc *)",
+      "Bash(deno info *)",
+      "Read(**)",
+      "Edit(**)"
+    ],
+    "deny": [
+      "Bash(git push * --force *)",
+      "Bash(git push --force *)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Edit(//**/.*env*)"
+    ]
+  },
   "mcpServers": {
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- Claude Codeのグローバル設定にpermissionsルールを追加
- gh/git/npm/deno等の日常的なコマンド実行とファイル読み書きを自動承認
- パッケージインストール・force push・rm -rf等の破壊的操作はdenyまたは確認を維持

## Test plan
- [ ] Claude Codeを再起動し、許可済みコマンド（`git status`等）が確認なしで実行されることを確認
- [ ] `npm install`等のパッケージ変更コマンドで確認ダイアログが表示されることを確認
- [ ] `rm -rf`等のdenyコマンドがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)