### PR TITLE
add: serenaのMCPツールをpermissionsに追加

### DIFF
--- a/mac/claude/settings.json
+++ b/mac/claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(deno bench *)",
       "Bash(deno doc *)",
       "Bash(deno info *)",
+      "mcp__serena__*",
       "Read(**)",
       "Edit(**)"
     ],


### PR DESCRIPTION
## Summary

- `mcp__serena__*` をClaudeのpermissions allowリストに追加
- SerenaのMemoryツール（`read_memory`、`write_memory`、`list_memories` など）をはじめ、全SerenaツールをClaudeが自動許可で使用可能にする

🤖 Generated with [Claude Code](https://claude.com/claude-code)