### PR TITLE
feat: ls を eza に置き換える

### DIFF
--- a/mac/zsh/.zshrc
+++ b/mac/zsh/.zshrc
@@ -23,11 +23,11 @@ export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
 eval "$(starship init zsh)"
 
 # -------------------------------------------------------------
-# ls コマンドに色を付ける
-alias ls='ls --color=auto'
-
-# al コマンドを作成する
-alias al='ls -al --color=auto'
+# eza を ls の代わりに使う
+alias ls='eza --icons'
+alias ll='eza -l --icons'
+alias la='eza -la --icons'
+alias al='eza -la --icons'
 
 # vim を nvim に置き換える
 alias vim='nvim'
@@ -46,3 +46,4 @@ esac
 
 # Added by Antigravity
 export PATH="/Users/shio3ch/.antigravity/antigravity/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
- `ls` を `eza --icons` に置き換え
- `ll`（ロング表示）エイリアスを追加
- `la` / `al`（隠しファイル込みロング表示）エイリアスを追加

## Test plan
- [ ] `brew install eza` でインストール済みか確認
- [ ] `source ~/.zshrc` 後に各エイリアスが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)