### PR TITLE
feat: Ghosttyに通知・リンクプレビュー・アイコン設定を追加

### DIFF
--- a/mac/ghostty/config
+++ b/mac/ghostty/config
@@ -146,3 +146,18 @@ keybind = ctrl+cmd+l=goto_split:right
 keybind = cmd+up=jump_to_prompt:-1
 keybind = cmd+down=jump_to_prompt:1
 
+# ========================================
+# その他の設定
+# ========================================
+
+# 通知
+notify-on-command-finish = unfocused
+notify-on-command-finish-action = no-bell,notify
+notify-on-command-finish-after = 2s
+
+# リンクのプレビュー
+link-previews = true
+
+# アイコンの変更
+macos-icon = xray
+


### PR DESCRIPTION
## Summary
- コマンド完了通知を追加（非フォーカス時、2秒後にnotify）
- リンクプレビューを有効化
- macOSアイコンを `xray` に変更

## Test plan
- [ ] Ghosttyを再起動して設定が反映されることを確認
- [ ] 長時間コマンド実行後に通知が来ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)