### PR TITLE
feat: Neovimのヤンクをシステムクリップボードと共有

### DIFF
--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -2,3 +2,4 @@
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- Add any additional options here
 vim.opt.spelllang = { "en", "cjk" }
+vim.opt.clipboard = "unnamedplus"


### PR DESCRIPTION
## Summary

- `clipboard=unnamedplus` を設定し、ヤンク・削除操作がシステムクリップボードと連携するようにした
- macOSでは `Cmd+V` で他アプリへの貼り付けが可能になる

## Test plan

- [ ] `chezmoi apply` で反映後、Neovimでテキストをヤンクして他アプリに貼り付けられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)