### PR TITLE
feat: zsh補完システム(compinit)を有効化

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,6 +1,10 @@
 [ -r /etc/zshrc ] && . /etc/zshrc
 
 # -------------------------------------------------------------
+# Completion
+autoload -U compinit && compinit
+
+# -------------------------------------------------------------
 # Load secrets (API keys, tokens, etc.)
 for file in ~/.secrets/*.sh(N); do
   source "$file"


### PR DESCRIPTION
## Summary
- `autoload -U compinit && compinit` を `.zshrc` の先頭付近に追加
- zshの補完システムを有効化

## Test plan
- [ ] `chezmoi apply` で `~/.zshrc` に反映されること
- [ ] 新しいシェルセッションでタブ補完が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)