### PR TITLE
feat: nvim-telescope の設定を強化

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -13,7 +13,7 @@ return {
     {
       "<leader>ff",
       function()
-        require("telescope.builtin").find_files()
+        require("telescope.builtin").find_files({ hidden = true })
       end,
       desc = "Find Files",
     },
@@ -38,11 +38,26 @@ return {
       end,
       desc = "Help Tags",
     },
+    {
+      "<leader>fr",
+      function()
+        require("telescope.builtin").oldfiles()
+      end,
+      desc = "Recent Files",
+    },
+    {
+      "<leader>fs",
+      function()
+        require("telescope.builtin").git_status()
+      end,
+      desc = "Git Status",
+    },
   },
   opts = function(_, opts)
     local actions = require("telescope.actions")
 
     opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
+      file_ignore_patterns = { "node_modules/", ".git/", "%.lock", "dist/", "build/" },
       mappings = {
         i = {
           ["<C-j>"] = actions.move_selection_next,


### PR DESCRIPTION
## Summary

- `find_files` に `hidden = true` を追加してドットファイルも検索対象に
- `file_ignore_patterns` で `node_modules/`, `.git/`, `dist/`, `build/`, `*.lock` を除外
- `<leader>fr` で Recent Files（oldfiles）を開くキーマップを追加
- `<leader>fs` で Git Status を開くキーマップを追加

## キーマップ一覧

| キー | 機能 |
|------|------|
| `<leader>ff` | Find Files（隠しファイル含む） |
| `<leader>fg` | Live Grep |
| `<leader>fb` | Find Buffers |
| `<leader>fh` | Help Tags |
| `<leader>fr` | Recent Files（新規追加） |
| `<leader>fs` | Git Status（新規追加） |

Closes #1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SskJRbsDHnGZQe3A6fPATd)_