### PR TITLE
feat: nvim-telescope の設定を拡充 (#1)

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -13,7 +13,7 @@ return {
     {
       "<leader>ff",
       function()
-        require("telescope.builtin").find_files()
+        require("telescope.builtin").find_files({ hidden = true })
       end,
       desc = "Find Files",
     },
@@ -38,15 +38,53 @@ return {
       end,
       desc = "Help Tags",
     },
+    {
+      "<leader>fr",
+      function()
+        require("telescope.builtin").oldfiles()
+      end,
+      desc = "Recent Files",
+    },
+    {
+      "<leader>fs",
+      function()
+        require("telescope.builtin").lsp_document_symbols()
+      end,
+      desc = "Document Symbols",
+    },
+    {
+      "<leader>fd",
+      function()
+        require("telescope.builtin").diagnostics()
+      end,
+      desc = "Diagnostics",
+    },
+    {
+      "<leader>gc",
+      function()
+        require("telescope.builtin").git_commits()
+      end,
+      desc = "Git Commits",
+    },
+    {
+      "<leader>gs",
+      function()
+        require("telescope.builtin").git_status()
+      end,
+      desc = "Git Status",
+    },
   },
   opts = function(_, opts)
     local actions = require("telescope.actions")
 
     opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
+      path_display = { "smart" },
+      file_ignore_patterns = { "node_modules/", ".git/", "%.lock" },
       mappings = {
         i = {
           ["<C-j>"] = actions.move_selection_next,
           ["<C-k>"] = actions.move_selection_previous,
+          ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
         },
       },
     })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

issue #1 の対応。nvim-telescope はすでに基本実装済みだったため、実用的なキーマップと設定を追加。

- `<leader>fr`: 最近開いたファイル (`oldfiles`)
- `<leader>fs`: LSP ドキュメントシンボル
- `<leader>fd`: Diagnostics 一覧
- `<leader>gc`: Git コミット履歴
- `<leader>gs`: Git ステータス
- `<leader>ff`: hidden ファイルも検索対象に追加
- `path_display = "smart"` でパス表示を最適化
- `file_ignore_patterns` で `node_modules/`, `.git/`, `*.lock` を除外
- `<C-q>` で検索結果を quickfix リストに送る操作を追加

Closes #1

https://claude.ai/code/session_01U4fsyK2yqMZCqJpLh6yNTs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4fsyK2yqMZCqJpLh6yNTs)_