### PR TITLE
feat: nvim-telescope のキーマップと設定を拡充

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -13,7 +13,7 @@ return {
     {
       "<leader>ff",
       function()
-        require("telescope.builtin").find_files()
+        require("telescope.builtin").find_files({ hidden = true })
       end,
       desc = "Find Files",
     },
@@ -38,15 +38,53 @@ return {
       end,
       desc = "Help Tags",
     },
+    {
+      "<leader>fr",
+      function()
+        require("telescope.builtin").oldfiles()
+      end,
+      desc = "Recent Files",
+    },
+    {
+      "<leader>fd",
+      function()
+        require("telescope.builtin").diagnostics()
+      end,
+      desc = "Diagnostics",
+    },
+    {
+      "<leader>fs",
+      function()
+        require("telescope.builtin").lsp_document_symbols()
+      end,
+      desc = "Document Symbols",
+    },
+    {
+      "<leader>gc",
+      function()
+        require("telescope.builtin").git_commits()
+      end,
+      desc = "Git Commits",
+    },
+    {
+      "<leader>gs",
+      function()
+        require("telescope.builtin").git_status()
+      end,
+      desc = "Git Status",
+    },
   },
   opts = function(_, opts)
     local actions = require("telescope.actions")
 
     opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
+      path_display = { "smart" },
+      file_ignore_patterns = { "node_modules/", "%.git/", "%.lock$", "dist/", "build/" },
       mappings = {
         i = {
           ["<C-j>"] = actions.move_selection_next,
           ["<C-k>"] = actions.move_selection_previous,
+          ["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
         },
       },
     })


### PR DESCRIPTION
## Summary

issue #1 の対応。既存の基本設定に実用的なキーマップと設定を追加。

**新規キーマップ**
- `<leader>fr`: 最近開いたファイル (`oldfiles`)
- `<leader>fd`: Diagnostics 一覧
- `<leader>fs`: LSP ドキュメントシンボル
- `<leader>gc`: Git コミット履歴
- `<leader>gs`: Git ステータス

**既存キーマップの改善**
- `<leader>ff`: hidden ファイルも検索対象に追加

**defaults の改善**
- `path_display = "smart"` でパス表示を最適化
- `file_ignore_patterns` で `node_modules/`, `.git/`, `*.lock`, `dist/`, `build/` を除外
- `<C-q>` で検索結果を quickfix リストに送る操作を追加

Closes #1

https://claude.ai/code/session_01NKcsE96my9z9zo7xnnHwG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKcsE96my9z9zo7xnnHwG5)_