### PR TITLE
feat: NeovimにJavaScript/TypeScript開発環境を追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ dotfiles/
 ├── dot_config/
 │   ├── git/ignore              # ~/.config/git/ignore
 │   ├── starship/starship.toml  # ~/.config/starship.toml
-│   ├── nvim/                   # ~/.config/nvim/（LazyVim）
+│   ├── nvim/                   # ~/.config/nvim/（LazyVim、JS/TS開発環境込み）
 │   └── ghostty/config          # ~/.config/ghostty/config
 ├── dot_claude/
 │   ├── CLAUDE.md               # ~/.claude/CLAUDE.md

--- a/dot_config/nvim/lazyvim.json
+++ b/dot_config/nvim/lazyvim.json
@@ -1,6 +1,9 @@
 {
   "extras": [
-    "lazyvim.plugins.extras.lang.prisma"
+    "lazyvim.plugins.extras.lang.prisma",
+    "lazyvim.plugins.extras.lang.typescript",
+    "lazyvim.plugins.extras.lang.json",
+    "lazyvim.plugins.extras.test.core"
   ],
   "install_version": 8,
   "news": {

--- a/dot_config/nvim/lua/plugins/conform.lua
+++ b/dot_config/nvim/lua/plugins/conform.lua
@@ -4,11 +4,16 @@ return {
   opts = {
     -- 各言語のフォーマッター設定
     formatters_by_ft = {
+      lua = { "stylua" },
       markdown = { "prettier" },
-      -- 他の言語のフォーマッターもここに追加可能
-      -- lua = { "stylua" },
-      -- javascript = { "prettier" },
-      -- typescript = { "prettier" },
+      javascript = { "prettier" },
+      javascriptreact = { "prettier" },
+      typescript = { "prettier" },
+      typescriptreact = { "prettier" },
+      json = { "prettier" },
+      jsonc = { "prettier" },
+      css = { "prettier" },
+      html = { "prettier" },
     },
   },
 }

--- a/dot_config/nvim/lua/plugins/mason.lua
+++ b/dot_config/nvim/lua/plugins/mason.lua
@@ -3,8 +3,10 @@ return {
   "mason-org/mason.nvim",
   opts = {
     ensure_installed = {
-      -- Markdownフォーマッター
       "prettier",
+      "stylua",
+      "typescript-language-server",
+      "eslint-lsp",
     },
   },
 }

--- a/dot_config/nvim/lua/plugins/neotest.lua
+++ b/dot_config/nvim/lua/plugins/neotest.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-neotest/neotest-jest",
+      "marilari88/neotest-vitest",
+    },
+    opts = function(_, opts)
+      vim.list_extend(opts.adapters, {
+        require("neotest-jest")({
+          jestCommand = "npx jest",
+          jestConfigFile = function(file)
+            local cwd = vim.fn.fnamemodify(file, ":p:h")
+            for _, name in ipairs({ "jest.config.js", "jest.config.ts", "jest.config.mjs" }) do
+              local path = cwd .. "/" .. name
+              if vim.fn.filereadable(path) == 1 then
+                return path
+              end
+            end
+          end,
+        }),
+        require("neotest-vitest"),
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary

- `lazyvim.json` に `lang.typescript`・`lang.json`・`test.core` extrasを追加
- `conform.lua` でJS/TS/JSX/TSX/JSON/CSS/HTMLにprettierフォーマットを適用
- `mason.lua` で `typescript-language-server`・`eslint-lsp`・`stylua` を自動インストール対象に追加
- `neotest.lua` を新規作成し、JestおよびVitestアダプターでテスト実行を設定

## 有効になる機能

- **コード補完**: tsserver LSPによる補完・型チェック・定義ジャンプ
- **フォーマット**: `<leader>cf` でprettier実行（保存時自動フォーマット）
- **テスト実行**: `<leader>tt` / `<leader>tT` でJest・Vitest両対応

## Test plan

- [ ] `cupdate` で反映後、Neovimを起動して `:Lazy sync` でプラグインインストールを確認
- [ ] JSファイルで保存時にprettierフォーマットが走ることを確認
- [ ] 補完・定義ジャンプが動作することを確認
- [ ] `<leader>tt` でテストが実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)