### PR TITLE
feat: Neovimの背景を透過しcatppuccin-mochaに統一

### DIFF
--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,16 @@
+return {
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    opts = {
+      flavour = "mocha",
+      transparent_background = true,
+    },
+  },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "catppuccin-mocha",
+    },
+  },
+}


### PR DESCRIPTION
## Summary

- `lua/plugins/colorscheme.lua` を新規追加
- カラースキームを LazyVim デフォルトの tokyonight から **catppuccin-mocha** に変更（Ghostty・Starship と統一）
- `transparent_background = true` で Neovim の背景を透過し、Ghostty のブラー背景が透けて見えるように

## Test plan

- [x] `cupdate` 後に Neovim を起動し、背景が透過されていることを確認
- [x] Ghostty の `background-opacity = 0.85` / `background-blur-radius = 15` 越しに背景が見えることを確認
- [x] カラーハイライト（LSP、Treesitter）が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)