### PR TITLE
feat: Neo-treeの背景を透過

### DIFF
--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -5,6 +5,13 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
+      custom_highlights = function(colors)
+        return {
+          NeoTreeNormal = { bg = "NONE" },
+          NeoTreeNormalNC = { bg = "NONE" },
+          NeoTreeEndOfBuffer = { bg = "NONE" },
+        }
+      end,
     },
   },
   {


### PR DESCRIPTION
## Summary

- catppuccin の `custom_highlights` で Neo-tree のハイライトグループを上書き
- `NeoTreeNormal` / `NeoTreeNormalNC` / `NeoTreeEndOfBuffer` の背景を `NONE` に設定

## Test plan

- [ ] `cupdate` 後に Neovim を起動し、Neo-tree の背景が透過されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)