### PR TITLE
feat: .chezmoiignoreを追加し外部ツール自動更新ファイルを管理対象外に

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,0 +1,3 @@
+# 外部ツールが自動更新するファイル
+.config/nvim/lazy-lock.json
+.claude/settings.json


### PR DESCRIPTION
## Summary

- `.chezmoiignore` を新規作成
- `cupdate` 時に毎回確認ダイアログが出ていた2ファイルを除外
  - `.config/nvim/lazy-lock.json` — lazy.nvim が起動時に自動更新
  - `.claude/settings.json` — Claude Code が自動更新

## Test plan

- [ ] `cupdate` 実行時に確認ダイアログが出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)