### PR TITLE
fix: Neo-treeの背景透過をautocmdで確実に適用

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -6,3 +6,12 @@
 --
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "neo-tree",
+  callback = function()
+    vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = "NONE" })
+    vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = "NONE" })
+    vim.api.nvim_set_hl(0, "NeoTreeEndOfBuffer", { bg = "NONE" })
+  end,
+})

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -5,13 +5,6 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
-      custom_highlights = function(colors)
-        return {
-          NeoTreeNormal = { bg = "NONE" },
-          NeoTreeNormalNC = { bg = "NONE" },
-          NeoTreeEndOfBuffer = { bg = "NONE" },
-        }
-      end,
     },
   },
   {


### PR DESCRIPTION
## Summary

- `custom_highlights` では Neo-tree が後からハイライトを上書きするため効かなかった
- `FileType neo-tree` の autocmd で Neo-tree が開いたタイミングに強制的に背景を `NONE` に設定する方式に変更
- `colorscheme.lua` から不要になった `custom_highlights` を削除

## Test plan

- [ ] `cupdate` 後に Neovim を起動し、Neo-tree の背景が透過されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)