### PR TITLE
fix: Neo-treeの透過をwinhighlightで直接適用

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -10,8 +10,6 @@
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "neo-tree",
   callback = function()
-    vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = "NONE" })
-    vim.api.nvim_set_hl(0, "NeoTreeEndOfBuffer", { bg = "NONE" })
+    vim.opt_local.winhighlight = "Normal:Normal,NormalNC:NormalNC,EndOfBuffer:EndOfBuffer"
   end,
 })


### PR DESCRIPTION
## Summary

- 前回の `vim.api.nvim_set_hl` によるハイライト変更は、Neo-tree が window の `winhighlight` で `NeoTreeNormal` にマッピングするため効かなかった
- `FileType neo-tree` の autocmd で `winhighlight` を直接上書きし、グローバルの透過済み `Normal` を使わせる方式に変更

## Test plan

- [ ] `cupdate` 後に Neovim を起動し、Neo-tree の背景が透過されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)