### PR TITLE
fix: NormalFloatを透過しSnacksピッカー等のfloating windowを透過

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -7,13 +7,3 @@
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
 
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = "neo-tree",
-  callback = function()
-    vim.schedule(function()
-      vim.api.nvim_set_hl(0, "NeoTreeNormal", { link = "Normal" })
-      vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { link = "NormalNC" })
-      vim.api.nvim_set_hl(0, "NeoTreeEndOfBuffer", { link = "EndOfBuffer" })
-    end)
-  end,
-})

--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -10,6 +10,10 @@
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "neo-tree",
   callback = function()
-    vim.opt_local.winhighlight = "Normal:Normal,NormalNC:NormalNC,EndOfBuffer:EndOfBuffer"
+    vim.schedule(function()
+      vim.api.nvim_set_hl(0, "NeoTreeNormal", { link = "Normal" })
+      vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { link = "NormalNC" })
+      vim.api.nvim_set_hl(0, "NeoTreeEndOfBuffer", { link = "EndOfBuffer" })
+    end)
   end,
 })

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -5,6 +5,12 @@ return {
     opts = {
       flavour = "mocha",
       transparent_background = true,
+      custom_highlights = function(colors)
+        return {
+          NormalFloat = { bg = "NONE" },
+          FloatBorder = { bg = "NONE" },
+        }
+      end,
     },
   },
   {


### PR DESCRIPTION
## Summary

- 「Neo-tree」と思っていたものが実は Snacks ピッカー（`snacks_picker_list`）だったと判明
- ハイライトのチェーンが `SnacksPickerList` → `SnacksPicker` → `NormalFloat` であったため、`NormalFloat` 自体を透過することで解決
- catppuccin の `custom_highlights` で `NormalFloat` / `FloatBorder` を `bg = NONE` に設定
- 効果のなかった Neo-tree 向け autocmd を削除

## Test plan

- [ ] `cupdate` 後に Neovim を起動し、Snacks ピッカーの背景が透過されていることを確認
- [ ] 補完・ホバーなど他の floating window も透過されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)