### PR TITLE
fix: ghosttyの背景透過を0.92に変更

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -54,7 +54,7 @@
 
 #theme = light:Catppuccin Latte,dark:Catppuccin Mocha
 theme = Catppuccin Mocha
-background-opacity = 0.85
+background-opacity = 0.92
 background-blur-radius = 15
 #font-family = "CaskaydiaCove Nerd Font Mono"
 #font-family = "Maple Mono"


### PR DESCRIPTION
## Summary
- `background-opacity` を `0.85` → `0.92` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)