### PR TITLE
feat: Snacks explorerで隠しファイルとgit未追跡ファイルをデフォルト表示

### DIFF
--- a/dot_config/nvim/lua/plugins/snacks.lua
+++ b/dot_config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,13 @@
+return {
+  "folke/snacks.nvim",
+  opts = {
+    picker = {
+      sources = {
+        explorer = {
+          hidden = true,
+          git_untracked = true,
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

- `lua/plugins/snacks.lua` を新規追加
- `hidden = true`: `.`で始まる隠しファイル（dotfiles等）をexplorerにデフォルト表示
- `git_untracked = true`: gitで追跡されていないファイルをexplorerにデフォルト表示

## Test plan

- [ ] Neovimを起動してSnacks explorerを開く
- [ ] 隠しファイル（`.env`等）が表示されることを確認
- [ ] git未追跡ファイルがexplorerに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)