### PR TITLE
fix: Snacks explorerでgit ignored扱いのファイルも表示

### DIFF
--- a/dot_config/nvim/lua/plugins/snacks.lua
+++ b/dot_config/nvim/lua/plugins/snacks.lua
@@ -6,6 +6,7 @@ return {
         explorer = {
           hidden = true,
           git_untracked = true,
+          git_ignored = true,
         },
       },
     },


### PR DESCRIPTION
## Summary

- `git_ignored = true` を追加

`.git/info/exclude` に登録されたファイルはgitに「無視（ignored）」扱いされるため、`git_untracked = true` だけでは表示されない。`git_ignored = true` を加えることで、excludeファイルに列挙されたファイルもexplorerに表示されるようになる。

## Test plan

- [ ] `.git/info/exclude` に登録されたファイルがSnacks explorerに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)