### PR TITLE
fix: Snacks explorerのignored表示オプション名を修正

### DIFF
--- a/dot_config/nvim/lua/plugins/snacks.lua
+++ b/dot_config/nvim/lua/plugins/snacks.lua
@@ -6,7 +6,7 @@ return {
         explorer = {
           hidden = true,
           git_untracked = true,
-          git_ignored = true,
+          ignored = true,
         },
       },
     },


### PR DESCRIPTION
## Summary

- `git_ignored = true` → `ignored = true` に修正

Snacksのソースコード（`tree.lua`）を確認したところ、ignored判定のフィルタオプションは `ignored` が正しい名前。`git_ignored` は存在しないオプションで無効だった。

```lua
-- tree.lua L220
if node.ignored and not filter.ignored then  -- ← opts.ignored を参照
```

## Test plan

- [ ] `.git/info/exclude` に登録されたファイルがSnacks explorerに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)